### PR TITLE
grab data for ocfl objects from the fs instead of storage service

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tempfile
 import unittest
 
 
@@ -15,14 +16,16 @@ if __name__ == '__main__':
     os.environ['STORAGE_SERVICE_PARAM'] = 'some_param=1'
     os.environ['COLLECTION_URL'] = 'http://localhost/collection_url/'
     os.environ['COLLECTION_URL_PARAM'] = 'some_param=1'
-    os.environ['CACHE_DIR'] = '/tmp'
-    os.environ['TEMP_DIR'] = '/tmp'
     os.environ['BDR_BROWN'] = 'brown'
     os.environ['BDR_PUBLIC'] = 'public'
-    loader = unittest.TestLoader()
-    tests = loader.discover(start_dir='.')
-    test_runner = unittest.TextTestRunner()
-    result = test_runner.run(tests)
+    with tempfile.TemporaryDirectory() as tmp:
+        os.environ['CACHE_DIR'] = tmp
+        os.environ['TEMP_DIR'] = tmp
+        os.environ['OCFL_ROOT'] = tmp
+        loader = unittest.TestLoader()
+        tests = loader.discover(start_dir='.')
+        test_runner = unittest.TextTestRunner()
+        result = test_runner.run(tests)
     if result.errors or result.failures:
         sys.exit(1)
     else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="bdr_solrizer",
-    version='4.8',
+    version='4.9',
     packages=find_packages(where='src'),
     package_dir={'': 'src'},
     scripts=['bin/queue_solrize'],

--- a/src/bdr_solrizer/settings.py
+++ b/src/bdr_solrizer/settings.py
@@ -26,4 +26,4 @@ INDEX_ZIP_QUEUE = 'solrizer_zip'
 TEMP_DIR = get_env_variable('TEMP_DIR')
 BDR_BROWN = get_env_variable('BDR_BROWN')
 BDR_PUBLIC = get_env_variable('BDR_PUBLIC')
-
+OCFL_ROOT = get_env_variable('OCFL_ROOT')

--- a/src/bdr_solrizer/solrizer.py
+++ b/src/bdr_solrizer/solrizer.py
@@ -121,4 +121,3 @@ def index_zip(pid):
         import traceback
         logger.error('index zip job failure for %s:  %s' % (pid, traceback.format_exc()))
         raise Exception('%s index zip (%s) error: %s' % (datetime.now(), pid, repr(e)))
-


### PR DESCRIPTION
This change would change the caches to put the content into the cache, instead of the response object. Also, if we do add a bdrocfl package, some of this new code could move there.