### PR TITLE
only check for ObjectNotFound or ObjectDeleted for the object being i…

### DIFF
--- a/bdr_solrizer/solrdocbuilder.py
+++ b/bdr_solrizer/solrdocbuilder.py
@@ -66,7 +66,6 @@ class StorageObject:
     def __init__(self, pid, use_object_cache=False):
         self.pid = pid
         self.use_object_cache = use_object_cache
-        self._ocfl_object = None
         try:
             self._ocfl_object = ocfl.Object(OCFL_ROOT, self.pid)
         except ocfl.ObjectNotFound:

--- a/bdr_solrizer/solrizer.py
+++ b/bdr_solrizer/solrizer.py
@@ -28,18 +28,20 @@ class Solrizer:
         else:
             try:
                 storage_object = StorageObject(self.pid)
-                if action == ZIP_ACTION:
-                    self._index_zip(storage_object)
-                elif action == IMAGE_PARENT_ACTION:
-                    self._index_image_parent(storage_object)
-                else:
-                    self._update_solr_document(storage_object, action)
             except ObjectNotFound:
                 #if object isn't in storage, it shouldn't be in solr either
                 self._delete_solr_document(self.pid)
+                return
             except ObjectDeleted:
-                if action != ZIP_ACTION:
-                    self._delete_solr_document(self.pid)
+                #if object is Deleted in storage, it shouldn't be in solr either
+                self._delete_solr_document(self.pid)
+                return
+            if action == ZIP_ACTION:
+                self._index_zip(storage_object)
+            elif action == IMAGE_PARENT_ACTION:
+                self._index_image_parent(storage_object)
+            else:
+                self._update_solr_document(storage_object, action)
 
     def _delete_solr_document(self, pid):
         logger.info(f'  deleting {pid} from solr')

--- a/tests/unit/test_solrizer.py
+++ b/tests/unit/test_solrizer.py
@@ -141,7 +141,9 @@ class TestSolrizer(unittest.TestCase):
 
     def test_index_zip_object_deleted(self):
         test_utils.create_deleted_object(storage_root=OCFL_ROOT, pid=self.pid)
-        solrizer.index_zip(self.pid)
+        with patch('bdr_solrizer.solrizer.Solrizer._post_to_solr') as post_to_solr:
+            solrizer.index_zip(self.pid)
+        post_to_solr.assert_called_once_with(json.dumps({'delete': {'id': self.pid}}), 'delete')
 
     def test_index_image_parent(self):
         test_utils.create_object(storage_root=OCFL_ROOT, pid=self.pid)


### PR DESCRIPTION
…ndexed, not for any parents or originals used during the processing