### PR TITLE
When <languageTerm> text corresponds to a ISO_6391 language code and …

### DIFF
--- a/bdr_solrizer/indexers/modsindexer.py
+++ b/bdr_solrizer/indexers/modsindexer.py
@@ -10,6 +10,8 @@ from .. import settings
 
 XLINK_NAMESPACE = 'http://www.w3.org/1999/xlink'
 
+ISO_6391_LANGUAGE_CODE_TO_ISO_6392B_LANGUAGE_CODE = {'aa': 'aar', 'ab': 'abk', 'af': 'afr', 'ak': 'aka', 'am': 'amh', 'ar': 'ara', 'an': 'arg', 'as': 'asm', 'av': 'ava', 'ae': 'ave', 'ay': 'aym', 'az': 'aze', 'ba': 'bak', 'bm': 'bam', 'be': 'bel', 'bn': 'ben', 'bh': 'bih', 'bi': 'bis', 'bo': 'tib', 'bs': 'bos', 'br': 'bre', 'bg': 'bul', 'ca': 'cat', 'cs': 'cze', 'ch': 'cha', 'ce': 'che', 'cu': 'chu', 'cv': 'chv', 'kw': 'cor', 'co': 'cos', 'cr': 'cre', 'cy': 'wel', 'da': 'dan', 'de': 'ger', 'dv': 'div', 'dz': 'dzo', 'el': 'gre', 'en': 'eng', 'eo': 'epo', 'et': 'est', 'eu': 'baq', 'ee': 'ewe', 'fo': 'fao', 'fa': 'per', 'fj': 'fij', 'fi': 'fin', 'fr': 'fre', 'fy': 'fry', 'ff': 'ful', 'gd': 'gla', 'ga': 'gle', 'gl': 'glg', 'gv': 'glv', 'gn': 'grn', 'gu': 'guj', 'ht': 'hat', 'ha': 'hau', 'he': 'heb', 'hz': 'her', 'hi': 'hin', 'ho': 'hmo', 'hr': 'hrv', 'hu': 'hun', 'hy': 'arm', 'ig': 'ibo', 'io': 'ido', 'ii': 'iii', 'iu': 'iku', 'ie': 'ile', 'ia': 'ina', 'id': 'ind', 'ik': 'ipk', 'is': 'ice', 'it': 'ita', 'jv': 'jav', 'ja': 'jpn', 'kl': 'kal', 'kn': 'kan', 'ks': 'kas', 'ka': 'geo', 'kr': 'kau', 'kk': 'kaz', 'km': 'khm', 'ki': 'kik', 'rw': 'kin', 'ky': 'kir', 'kv': 'kom', 'kg': 'kon', 'ko': 'kor', 'kj': 'kua', 'ku': 'kur', 'lo': 'lao', 'la': 'lat', 'lv': 'lav', 'li': 'lim', 'ln': 'lin', 'lt': 'lit', 'lb': 'ltz', 'lu': 'lub', 'lg': 'lug', 'mh': 'mah', 'ml': 'mal', 'mr': 'mar', 'mk': 'mac', 'mg': 'mlg', 'mt': 'mlt', 'mn': 'mon', 'mi': 'mao', 'ms': 'may', 'my': 'bur', 'na': 'nau', 'nv': 'nav', 'nr': 'nbl', 'nd': 'nde', 'ng': 'ndo', 'ne': 'nep', 'nl': 'dut', 'nn': 'nno', 'nb': 'nob', 'no': 'nor', 'ny': 'nya', 'oc': 'oci', 'oj': 'oji', 'or': 'ori', 'om': 'orm', 'os': 'oss', 'pa': 'pan', 'pi': 'pli', 'pl': 'pol', 'pt': 'por', 'ps': 'pus', 'qu': 'que', 'rm': 'roh', 'ro': 'rum', 'rn': 'run', 'ru': 'rus', 'sg': 'sag', 'sa': 'san', 'si': 'sin', 'sk': 'slo', 'sl': 'slv', 'se': 'sme', 'sm': 'smo', 'sn': 'sna', 'sd': 'snd', 'so': 'som', 'st': 'sot', 'es': 'spa', 'sq': 'alb', 'sc': 'srd', 'sr': 'srp', 'ss': 'ssw', 'su': 'sun', 'sw': 'swa', 'sv': 'swe', 'ty': 'tah', 'ta': 'tam', 'tt': 'tat', 'te': 'tel', 'tg': 'tgk', 'tl': 'tgl', 'th': 'tha', 'ti': 'tir', 'to': 'ton', 'tn': 'tsn', 'ts': 'tso', 'tk': 'tuk', 'tr': 'tur', 'tw': 'twi', 'ug': 'uig', 'uk': 'ukr', 'ur': 'urd', 'uz': 'uzb', 've': 'ven', 'vi': 'vie', 'vo': 'vol', 'wa': 'wln', 'wo': 'wol', 'xh': 'xho', 'yi': 'yid', 'yo': 'yor', 'za': 'zha', 'zh': 'chi', 'zu': 'zul'}
+
 class ModsIndexer(CommonIndexer):
 
     JOINER_TEXT = ' > '
@@ -236,12 +238,18 @@ class ModsIndexer(CommonIndexer):
                           )
         for term in language_terms:
             self.append_field('mods_language_ssim', term.text)
+
             if term.type:
+                mods_language_code_ssim_text = term.text
+
+                if term.authority == "rfc3066" and ISO_6391_LANGUAGE_CODE_TO_ISO_6392B_LANGUAGE_CODE.get(term.text):
+                    mods_language_code_ssim_text = ISO_6391_LANGUAGE_CODE_TO_ISO_6392B_LANGUAGE_CODE.get(term.text, term.text)
+
                 self.append_field(
                         'mods_language_{}_ssim'.format(
                             self._slugify(term.type)
                         ),
-                        term.text
+                        mods_language_code_ssim_text
                 )
         return self
 

--- a/tests/unit/test_modsindexer.py
+++ b/tests/unit/test_modsindexer.py
@@ -838,6 +838,27 @@ class TestModsIndexer(unittest.TestCase):
        ''')
         index_data = indexer.index_data()
         self.assertEqual(index_data['primary_title'], u'Poétry')
+    
+    def test_rfc3066_to_iso6392b_language_code_mapping(self):
+        indexer = self.indexer_for_mods_string(u'''
+          <mods:language>
+            <mods:languageTerm authority="rfc3066" type="code">en</mods:languageTerm>
+          </mods:language>
+          <mods:language>
+            <mods:languageTerm authority="rfc3066" type="code">de</mods:languageTerm>
+          </mods:language>
+          <mods:language>
+            <mods:languageTerm authority="rfc3066" type="code">zz</mods:languageTerm>
+          </mods:language>
+          <mods:language>
+            <mods:languageTerm type="code">dan</mods:languageTerm>
+          </mods:language>
+          <mods:language>
+            <mods:languageTerm authority="iso639-2b">aa</mods:languageTerm>
+          </mods:language>
+       ''')
+        index_data = indexer.index_data()
+        self.assertEqual(index_data['mods_language_code_ssim'], ['eng','ger', 'zz', 'dan'])
 
 
 def suite():


### PR DESCRIPTION
…the authority attribute equals rfc3066, map the language code to a ISO_6392B language code in mods_language_code_ssim